### PR TITLE
Fix typo and make error clearer.

### DIFF
--- a/login_ldap.php
+++ b/login_ldap.php
@@ -103,9 +103,8 @@
 				}
 				exit;
 			} else {
-				$content="<h3>Login failed.</h3>You are in maintenance mode, as set by the site" .
-					"administrator in the database.";
-				debug_error_log("Maintenance mode is set and invalid credentials were passed.");
+				$content="<h3>Login failed.</h3>You are in LDAP debug mode, as set by the site administrator in the database.";
+				debug_error_log("LDAP debug mode is set and invalid credentials were passed.");
 			}
 		} else {
 			$ldapConn=ldap_connect($config->ParameterArray['LDAPServer']);


### PR DESCRIPTION
Adds a space between "siteadministrator". Also make the message displayed a bit clearer to the user. I was caught out by this and I saw someone on the mailing list was caught out by this too, i.e. mention "LDAP debug mode" rather than "maintenance mode" (which doesn't exist).