### PR TITLE
Error: Timezone is always set to 'America/Chicago'!

### DIFF
--- a/facilities.inc.php
+++ b/facilities.inc.php
@@ -33,7 +33,7 @@ if (!ini_get('date.timezone')) {
 	ini_set('date.timezone', 'America/Chicago');
 }
 
-if ( isset( $config ) && method_exists( "config", "ParameterArray" ) ){
+if ( isset( $config ) && property_exists( $config, "ParameterArray" ) ){
 	date_default_timezone_set($config->ParameterArray['timezone']);
 } elseif ( getenv("TZ") != "" ) {
 	date_default_timezone_set( getenv("TZ"));


### PR DESCRIPTION
The Config class has a property, not a method. The method reference causes the time zone to never be taken from the openDCIM configuration, but hardcoded to 'America/Chicago' :-(.