### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/cabaudit.php
+++ b/cabaudit.php
@@ -37,7 +37,7 @@ class PDF extends FPDF {
   var $pdfconfig;
 
   
-	function PDF(){
+	function __construct(){
 		parent::FPDF('L');
 	}
   

--- a/cabaudit.php
+++ b/cabaudit.php
@@ -38,7 +38,7 @@ class PDF extends FPDF {
 
   
 	function __construct(){
-		parent::FPDF('L');
+		parent::__construct('L');
 	}
   
 	function Header() {


### PR DESCRIPTION
… PHP 7!

FILE: cabaudit.php
---------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
---------------------------------------------------------------------------------------------
 40 | WARNING | Use of deprecated PHP4 style class constructor is not supported since PHP 7.
---------------------------------------------------------------------------------------------