### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -4,7 +4,7 @@ class Config{
 	var $ParameterArray;
 	var $defaults;
 	
-	function Config(){
+	function __construct(){
 		global $dbh;
 		
 		//Get parameter value pairs from fac_Config


### PR DESCRIPTION
… PHP 7!

FILE: config.inc.php
--------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------------------
 7 | WARNING | Use of deprecated PHP4 style class constructor is not supported since PHP 7.
--------------------------------------------------------------------------------------------