### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/report_aging.php
+++ b/report_aging.php
@@ -77,7 +77,7 @@ class PDF extends FPDF
     var $pdfconfig;
     var $pdfDB;
 
-    function PDF() {
+    function __construct() {
         parent::FPDF();
     }
 

--- a/report_aging.php
+++ b/report_aging.php
@@ -78,7 +78,7 @@ class PDF extends FPDF
     var $pdfDB;
 
     function __construct() {
-        parent::FPDF();
+        parent::__construct();
     }
 
     function Header() {


### PR DESCRIPTION
… PHP 7!

FILE: report_aging.php
---------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
---------------------------------------------------------------------------------------------
 80 | WARNING | Use of deprecated PHP4 style class constructor is not supported since PHP 7.
---------------------------------------------------------------------------------------------