### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/report_asset.php
+++ b/report_asset.php
@@ -12,7 +12,7 @@ class PDF extends FPDF {
   var $pdfDB;
   
 	function __construct(){
-		parent::FPDF();
+		parent::__construct();
 	}
   
 	function Header() {

--- a/report_asset.php
+++ b/report_asset.php
@@ -11,7 +11,7 @@ class PDF extends FPDF {
   var $pdfconfig;
   var $pdfDB;
   
-	function PDF(){
+	function __construct(){
 		parent::FPDF();
 	}
   


### PR DESCRIPTION
… PHP 7!

FILE: report_asset.php
---------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
---------------------------------------------------------------------------------------------
 14 | WARNING | Use of deprecated PHP4 style class constructor is not supported since PHP 7.
---------------------------------------------------------------------------------------------