### PR TITLE
Function each() is deprecated since PHP 7.2; Use a foreach loop instead!

### DIFF
--- a/report_cabinets.php
+++ b/report_cabinets.php
@@ -187,7 +187,7 @@
         $body.="<tr><td class=\"cabpos\">".__("Pos")."</td><td>".__("Device")."</td></tr></thead><tbody>";
 
         $heighterr="";
-        while(list($dev_index,$device)=each($devList)){
+        foreach($devList as $dev_index=>$device){
             list($noTemplFlag, $noOwnerFlag, $highlight) =
                 renderUnassignedTemplateOwnership($noTemplFlag, $noOwnerFlag, $device);
             if($device->Height<1 && !$rear){


### PR DESCRIPTION
FILE: report_cabinets.php
-----------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------
 190 | WARNING | Function each() is deprecated since PHP 7.2; Use a foreach loop instead
-----------------------------------------------------------------------------------------