### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/report_power_distribution.php
+++ b/report_power_distribution.php
@@ -18,7 +18,7 @@ class PDF extends FPDF {
   var $pdfDB;
   
 	function __construct(){
-		parent::FPDF();
+		parent::__construct();
 	}
   
 	function Header() {

--- a/report_power_distribution.php
+++ b/report_power_distribution.php
@@ -17,7 +17,7 @@ class PDF extends FPDF {
   var $pdfconfig;
   var $pdfDB;
   
-	function PDF(){
+	function __construct(){
 		parent::FPDF();
 	}
   


### PR DESCRIPTION
… PHP 7!

FILE: report_power_distribution.php
---------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
---------------------------------------------------------------------------------------------
 20 | WARNING | Use of deprecated PHP4 style class constructor is not supported since PHP 7.
---------------------------------------------------------------------------------------------