### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/report_vm_by_department.php
+++ b/report_vm_by_department.php
@@ -23,7 +23,7 @@ class PDF extends FPDF {
   var $pdfconfig;
   var $pdfDB;
   
-	function PDF(){
+	function __construct(){
 		parent::FPDF();
 	}
   

--- a/report_vm_by_department.php
+++ b/report_vm_by_department.php
@@ -24,7 +24,7 @@ class PDF extends FPDF {
   var $pdfDB;
   
 	function __construct(){
-		parent::FPDF();
+		parent::__construct();
 	}
   
 	function Header() {


### PR DESCRIPTION
… PHP 7!

FILE: report_vm_by_department.php
---------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
---------------------------------------------------------------------------------------------
 26 | WARNING | Use of deprecated PHP4 style class constructor is not supported since PHP 7.
---------------------------------------------------------------------------------------------