### PR TITLE
Use of deprecated PHP4 style class constructor is not supported since…

### DIFF
--- a/report_warranty.php
+++ b/report_warranty.php
@@ -92,7 +92,7 @@ class PDF extends FPDF
     var $pdfconfig;
     var $pdfDB;
 
-    function PDF() {
+    function __construct() {
         parent::FPDF();
     }
 

--- a/report_warranty.php
+++ b/report_warranty.php
@@ -93,7 +93,7 @@ class PDF extends FPDF
     var $pdfDB;
 
     function __construct() {
-        parent::FPDF();
+        parent::__construct();
     }
 
     function Header() {


### PR DESCRIPTION
… PHP 7!

FILE: report_warranty.php
---------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
---------------------------------------------------------------------------------------------
 95 | WARNING | Use of deprecated PHP4 style class constructor is not supported since PHP 7.
---------------------------------------------------------------------------------------------