### PR TITLE
Function each() is deprecated since PHP 7.2; Use a foreach loop instead!

### DIFF
--- a/classes/DataCenter.class.php
+++ b/classes/DataCenter.class.php
@@ -604,7 +604,7 @@ class DataCenter {
 
 		$zone->DataCenterID=$this->DataCenterID;
 		$zoneList=$zone->GetZonesByDC(); 
-		while(list($zoneNum,$myzone)=each($zoneList)){
+		foreach($zoneList as $zoneNum=>$myzone){
 			$tree.=str_repeat(" ",$lev+3)."<li class=\"liClosed\" id=\"zone$myzone->ZoneID\"><a class=\"ZONE\" href=\"zone_stats.php?zone="
 				."$myzone->ZoneID\">$myzone->Description</a>\n";
 			$tree.=str_repeat(" ",$lev+4)."<ul>\n";


### PR DESCRIPTION
FILE: classes/DataCenter.class.php
-----------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------
 607 | WARNING | Function each() is deprecated since PHP 7.2; Use a foreach loop instead
-----------------------------------------------------------------------------------------