### PR TITLE
The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_g…

### DIFF
--- a/oauth/http.php
+++ b/oauth/http.php
@@ -432,7 +432,7 @@ class http_class
 				case -7:
 					return($this->SetError("setvbuf() call failed", $error_code));
 				default:
-					return($this->SetPHPError($errno." could not connect to the host \"".$host_name."\"",$php_errormsg, $error_code));
+					return($this->SetPHPError($errno." could not connect to the host \"".$host_name."\"",error_get_last(), $error_code));
 			}
 		}
 		else
@@ -990,9 +990,9 @@ class http_class
 			if(GetType($length=@filesize($file["FileName"]))!="integer")
 			{
 				$error="it was not possible to determine the length of the file ".$file["FileName"];
-				if(IsSet($php_errormsg)
-				&& strlen($php_errormsg))
-					$error.=": ".$php_errormsg;
+				if(IsSet(error_get_last())
+				&& strlen(error_get_last()))
+					$error.=": ".error_get_last();
 				if(!file_exists($file["FileName"]))
 					$error="it was not possible to access the file ".$file["FileName"];
 				return($error);
@@ -1036,7 +1036,7 @@ class http_class
 			case "200":
 				if(!@stream_socket_enable_crypto($this->connection, 1, STREAM_CRYPTO_METHOD_SSLv23_CLIENT))
 				{
-					$this->SetPHPError('it was not possible to start a SSL encrypted connection via this proxy', $php_errormsg, HTTP_CLIENT_ERROR_COMMUNICATION_FAILURE);
+					$this->SetPHPError('it was not possible to start a SSL encrypted connection via this proxy', error_get_last(), HTTP_CLIENT_ERROR_COMMUNICATION_FAILURE);
 					$this->Disconnect();
 					return($this->error);
 				}
@@ -1215,12 +1215,12 @@ class http_class
 					elseif(IsSet($stream[$part]["File"]))
 					{
 						if(!($file=@fopen($stream[$part]["File"],"rb")))
-							return($this->SetPHPError("could not open upload file ".$stream[$part]["File"], $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE));
+							return($this->SetPHPError("could not open upload file ".$stream[$part]["File"], error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE));
 						while(!feof($file))
 						{
 							if(GetType($block=@fread($file,$this->file_buffer_length))!="string")
 							{
-								$error=$this->SetPHPError("could not read body stream file ".$stream[$part]["File"], $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+								$error=$this->SetPHPError("could not read body stream file ".$stream[$part]["File"], error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 								fclose($file);
 								return($error);
 							}
@@ -1334,7 +1334,7 @@ class http_class
 					{
 						if(!($file=@fopen($post_parts[$part]["FILENAME"],"rb")))
 						{
-							$this->SetPHPError("could not open upload file ".$post_parts[$part]["FILENAME"], $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+							$this->SetPHPError("could not open upload file ".$post_parts[$part]["FILENAME"], error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 							$success=0;
 							break;
 						}
@@ -1342,7 +1342,7 @@ class http_class
 						{
 							if(GetType($block=@fread($file,$this->file_buffer_length))!="string")
 							{
-								$this->SetPHPError("could not read upload file", $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+								$this->SetPHPError("could not read upload file", error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 								$success=0;
 								break;
 							}
@@ -1403,7 +1403,7 @@ class http_class
 								{
 									if(!($file=@fopen($post_parts[$part]["FILENAME"],"rb")))
 									{
-										$this->SetPHPError("could not open upload file ".$post_parts[$part]["FILENAME"], $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+										$this->SetPHPError("could not open upload file ".$post_parts[$part]["FILENAME"], error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 										$success=0;
 										break;
 									}
@@ -1411,7 +1411,7 @@ class http_class
 									{
 										if(GetType($block=@fread($file,$this->file_buffer_length))!="string")
 										{
-											$this->SetPHPError("could not read upload file", $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+											$this->SetPHPError("could not read upload file", error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 											$success=0;
 											break;
 										}
@@ -2001,7 +2001,7 @@ class http_class
 	Function ReadWholeReplyIntoTemporaryFile(&$file)
 	{
 		if(!($file = tmpfile()))
-			return $this->SetPHPError('could not create the temporary file to save the response', $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+			return $this->SetPHPError('could not create the temporary file to save the response', error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 		for(;;)
 		{
 			if(strlen($error = $this->ReadReplyBody($block, $this->file_buffer_length)))
@@ -2013,7 +2013,7 @@ class http_class
 			{
 				if(@fseek($file, 0) != 0)
 				{
-					$error = $this->SetPHPError('could not seek to the beginning of temporary file with the response', $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+					$error = $this->SetPHPError('could not seek to the beginning of temporary file with the response', error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 					fclose($file);
 					return $error;
 				}
@@ -2021,7 +2021,7 @@ class http_class
 			}
 			if(!@fwrite($file, $block))
 			{
-				$error = $this->SetPHPError('could not write to the temporary file to save the response', $php_errormsg, HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
+				$error = $this->SetPHPError('could not write to the temporary file to save the response', error_get_last(), HTTP_CLIENT_ERROR_CANNOT_ACCESS_LOCAL_FILE);
 				fclose($file);
 				return $error;
 			}


### PR DESCRIPTION
…et_last() instead!

FILE: oauth/http.php
---------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 14 WARNINGS AFFECTING 14 LINES
---------------------------------------------------------------------------------------------------------
  435 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
  993 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
  994 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
  995 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 1039 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 1218 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 1223 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 1337 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 1345 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 1406 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 1414 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 2004 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 2016 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
 2024 | WARNING | The variable '$php_errormsg' is deprecated since PHP 7.2; Use error_get_last() instead
---------------------------------------------------------------------------------------------------------