### PR TITLE
Indirect access to variables, properties and methods will be evaluate…

### DIFF
--- a/scripts/ajax_tooltip.php
+++ b/scripts/ajax_tooltip.php
@@ -114,7 +114,7 @@ if($object>0){
 			$HumMax=intval($config->ParameterArray["HumidityRedHigh"]);
 						
 			
-			while(list($devID,$device)=each($devList)){
+			foreach($devList as $devID=>$device){
 				$totalWatts+=$device->GetDeviceTotalPower();
 				$DeviceTotalWeight=$device->GetDeviceTotalWeight();
 				$totalWeight+=$DeviceTotalWeight;
@@ -229,27 +229,27 @@ if($object>0){
 			switch($row["Field"]){
 				case "SNMPCommunity":
 					if(isset($pdu->SNMPCommunity)){
-						$tooltip.=__($row["Label"]).": ".$pdu->$row["Field"]."<br>\n";
+						$tooltip.=__($row["Label"]).": ".$pdu->{$row["Field"]}."<br>\n";
 					}else{
 						if($dev->Hypervisor){
-							$tooltip.=__($row["Label"]).": ".$dev->$row["Field"]."<br>\n";
+							$tooltip.=__($row["Label"]).": ".$dev->{$row["Field"]}."<br>\n";
 						}
 					}
 					break;
 				case "Hypervisor":
 					if($dev->Hypervisor){
-						$tooltip.=__($row["Label"]).": ".$dev->$row["Field"]."<br>\n";
+						$tooltip.=__($row["Label"]).": ".$dev->{$row["Field"]}."<br>\n";
 					}
 					break;
 				case "EscalationID":
 					$esc=new Escalations();
-					$esc->EscalationID=$dev->$row["Field"];
+					$esc->EscalationID=$dev->{$row["Field"]};
 					$esc->GetEscalation();
 					$tooltip.=__($row["Label"]).": $esc->Details<br>\n";
 					break;
 				case "EscalationTimeID":
 					$escTime=new EscalationTimes();
-					$escTime->EscalationTimeID=$dev->$row["Field"];
+					$escTime->EscalationTimeID=$dev->{$row["Field"]};
 					$escTime->GetEscalationTime();
 					$tooltip.=__($row["Label"]).": $escTime->TimePeriod<br>\n";
 					break;
@@ -270,7 +270,7 @@ if($object>0){
 					break;
 				case "ChassisSlots":
 					if($dev->DeviceType=='Chassis'){
-						$tooltip.=__($row["Label"])." ".$dev->$row["Field"]."<br>\n";
+						$tooltip.=__($row["Label"])." ".$dev->{$row["Field"]}."<br>\n";
 					}
 					break;
 				case "Model":
@@ -319,10 +319,10 @@ if($object>0){
 					}
 					break;
 				case "Weight":
-					$dev->$row["Field"]=$dev->GetDeviceTotalWeight();
+					$dev->{$row["Field"]}=$dev->GetDeviceTotalWeight();
 					goto end; // cringe now
 				case "NominalWatts":
-					$dev->$row["Field"]=$dev->GetDeviceTotalPower();
+					$dev->{$row["Field"]}=$dev->GetDeviceTotalPower();
 					goto end; // fuck you, yeah I really did that
 				case "DeviceType":
 					// if this is a chassis device display the number of blades?


### PR DESCRIPTION
…d strictly in left-order since PHP 7.0. Use curly braces to remove ambiguity!

FILE: scripts/ajax_tooltip.php
FOUND 8 ERRORS AND 1 WARNING AFFECTING 9 LINES
117 | WARNING | Function each() is deprecated since PHP 7.2; Use a foreach loop instead
232 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.
235 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.
241 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.
246 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.
252 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.
273 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.
322 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.
325 | ERROR | Indirect access to variables, properties and methods will be evaluated strictly in left-to-right
|   | order since PHP 7.0. Use curly braces to remove ambiguity.