### PR TITLE
The left-associativity of the ternary operator has been deprecated in…

### DIFF
--- a/classes/Device.class.php
+++ b/classes/Device.class.php
@@ -366,7 +366,7 @@ class Device {
 		$snmpHost=new OSS_SNMP\SNMP($dev->PrimaryIP,$dev->SNMPCommunity,$dev->SNMPVersion,$dev->v3SecurityLevel,$dev->v3AuthProtocol,$dev->v3AuthPassphrase,$dev->v3PrivProtocol,$dev->v3PrivPassphrase);
 		$snmpresult=false;
 		try {
-			$snmpresult=(is_null($oid))?$snmpHost->useSystem()->$snmplookup(true):($walk)?$snmpHost->realWalk($oid):$snmpHost->get($oid);
+			$snmpresult=(is_null($oid))?$snmpHost->useSystem()->$snmplookup(true):(($walk)?$snmpHost->realWalk($oid):$snmpHost->get($oid));
 		}catch (Exception $e){
 			$dev->IncrementFailures();
 			error_log("Device::$caller($dev->DeviceID) ".$e->getMessage());


### PR DESCRIPTION
… PHP 7.4. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations!

FILE: classes/Device.class.php
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 369 | WARNING | The left-associativity of the ternary operator has been deprecated in PHP 7.4. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations
     |         | should be executed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------