### PR TITLE
The left-associativity of the ternary operator has been deprecated in…

### DIFF
--- a/classes/DevicePorts.class.php
+++ b/classes/DevicePorts.class.php
@@ -182,7 +182,7 @@ class DevicePorts {
 					}
 				}
 				// pull port name first from snmp then from template then just call it port x
-				$portList[$i]->Label=(isset($nameList[$n]))?$nameList[$n]:(isset($tports[$i]) && $tports[$i]->Label)?$tports[$i]->Label:__("Port").$i;
+				$portList[$i]->Label=(isset($nameList[$n]))?$nameList[$n]:((isset($tports[$i]) && $tports[$i]->Label)?$tports[$i]->Label:__("Port").$i);
 				$portList[$i]->Notes=(isset($aliasList[$n]))?$aliasList[$n]:'';
 				$portList[$i]->createPort($update_existing);
 			}


### PR DESCRIPTION
… PHP 7.4. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations should be executed!

FILE: classes/DevicePorts.class.php
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 185 | WARNING | The left-associativity of the ternary operator has been deprecated in PHP 7.4. Multiple consecutive ternaries detected. Use parenthesis to clarify the order in which the operations
     |         | should be executed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------