### PR TITLE
Fixes #1391 where browser password managers may write sensitive user …

### DIFF
--- a/devices.php
+++ b/devices.php
@@ -1778,7 +1778,7 @@ echo($copy)?"<h3>$copyerr</h3>":'';
 echo '<div class="center"><div>
 <h3></h3><h3 id="messages"></h3>
 <div id="Positionselector"></div>
-<form name="deviceform" id="deviceform" method="POST" autocomplete="off">
+<form name="deviceform" id="deviceform" method="POST" autocomplete="new-password">
 <div class="left">
 <fieldset>
 	<legend>'.__("Asset Tracking").'</legend>
@@ -2058,11 +2058,11 @@ echo '
 	<div class="table">
 		<div>
 		  <div><label for="APIUsername">'.__("API Username").'</label></div>
-		  <div><input autocomplete="off" type="text" name="APIUsername" id="APIUsername" value="'.$dev->APIUsername.'"></div>
+		  <div><input autocomplete="new-password" type="text" name="APIUsername" id="APIUsername" value="'.$dev->APIUsername.'"></div>
 		</div>
 		<div>
 		  <div><label for="APIPassword">'.__("API Password").'</label></div>
-		  <div><input autocomplete="off" type="password" name="APIPassword" id="APIPassword" value="'.$dev->APIPassword.'"></div>
+		  <div><input autocomplete="new-password" type="password" name="APIPassword" id="APIPassword" value="'.$dev->APIPassword.'"></div>
 		</div>
 		<div>
 		  <div><label for="APIPort">'.__("API Port").'</label></div>
@@ -2122,7 +2122,7 @@ echo '
 		</div>
 		<div>
 		  <div><label for="v3AuthPassphrase">'.__("SNMPv3 Passphrase").'</label></div>
-		  <div><input autocomplete="off" type="password" name="v3AuthPassphrase" id="v3AuthPassphrase" value="'.$dev->v3AuthPassphrase.'"></div>
+		  <div><input autocomplete="new-password" type="password" name="v3AuthPassphrase" id="v3AuthPassphrase" value="'.$dev->v3AuthPassphrase.'"></div>
 		</div>
 		<div>
 		  <div><label for="v3PrivProtocol">'.__("SNMPv3 PrivProtocol").'</label></div>
@@ -2139,7 +2139,7 @@ echo '
 		</div>
 		<div>
 		  <div><label for="v3PrivPassphrase">'.__("SNMPv3 PrivPassphrase").'</label></div>
-		  <div><input autocomplete="off" type="password" name="v3PrivPassphrase" id="v3PrivPassphrase" value="'.$dev->v3PrivPassphrase.'"></div>
+		  <div><input autocomplete="new-password" type="password" name="v3PrivPassphrase" id="v3PrivPassphrase" value="'.$dev->v3PrivPassphrase.'"></div>
 		</div>
 		<div>
 		  <div><label for="SNMPFailureCount">'.__("Consecutive SNMP Failures").'*</label></div>


### PR DESCRIPTION
…credentials to proxmox fields which are not visible to the user, leading to invisible credential leaks that other users can find in resulting HTML sent from the server with the current values.  autocomplete='new-password' tells the browser to not autofill as if this is a field meant for a new password to be created.  This is implemented across firefox, chrome, safari and presumably derivatives; perhaps others.  https://bugzilla.mozilla.org/show_bug.cgi?id=1119063
https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/

This was tested in a local installation of opendcim where a browser was writing credentials into these non-protected fields, and this did successfully change the browser behavior to stop leaking credentials from the password manager.