### PR TITLE
Proposed fix for #1391 - in JS set proxmox username/password fields t…

### DIFF
--- a/devices.php
+++ b/devices.php
@@ -1394,13 +1394,12 @@ $(document).ready(function() {
 		if($(this).val()=='ProxMox'){
 			$('#proxmoxblock').removeClass('hide');
 			$('#snmpblock').addClass('hide');
-			$('#APIUsername').attr("type","text");
 			$('#APIPassword').attr("type","password");
 		}else{
 			// Put back any hidden / renamed fields
 			$('#proxmoxblock').addClass('hide');
 			$('#snmpblock').removeClass('hide');
-			$('#APIUsername,#APIPassword').attr("type","hidden");
+			$('#APIPassword').attr("type","hidden");
 		}
 	}).change();
 
@@ -2057,7 +2056,6 @@ echo '
 	</div>
 </fieldset>';
 
-$apiusernamefieldtype = ($dev->Hypervisor==proxmox)?"text":"hidden";
 $apipasswordfieldtype = ($dev->Hypervisor==proxmox)?"password":"hidden";
 
 echo '<fieldset id="proxmoxblock" class="hide">
@@ -2065,7 +2063,7 @@ echo '<fieldset id="proxmoxblock" class="hide">
 	<div class="table">
 		<div>
 		  <div><label for="APIUsername">'.__("API Username").'</label></div>
-		  <div><input autocomplete="off" type=".$apiusernamefieldtype." name="APIUsername" id="APIUsername" value="'.$dev->APIUsername.'"></div>
+		  <div><input autocomplete="off" type="text" name="APIUsername" id="APIUsername" value="'.$dev->APIUsername.'"></div>
 		</div>
 		<div>
 		  <div><label for="APIPassword">'.__("API Password").'</label></div>

--- a/devices.php
+++ b/devices.php
@@ -2046,6 +2046,11 @@ echo '<fieldset id="sensorreadings">
 		</fieldset>';
 		}
 
+echo '<fieldset id="deviceimages">
+	<legend>'.__("Device Images").'</legend>
+	<div>';
+		$frontpic=($templ->FrontPictureFile!='')?' src="'.$config->ParameterArray['picturepath'].'/'.$templ->FrontPictureFile.'"':'';
+		$rearpic=($templ->RearPictureFile!='')?' src="'.$config->ParameterArray['picturepath'].'/'.$templ->RearPictureFile.'"':'';
 echo '
 		<img id="devicefront" src="'.$config->ParameterArray['picturepath'].'/'.$templ->FrontPictureFile.'" alt="front of device">
 		<img id="devicerear" src="'.$config->ParameterArray['picturepath'].'/'.$templ->RearPictureFile.'" alt="rear of device">

--- a/devices.php
+++ b/devices.php
@@ -1263,8 +1263,8 @@ $(document).ready(function() {
 		$('#pdutest').dialog({minWidth: 850, position: { my: "center", at: "top", of: window },closeOnEscape: true });
 	});
 
-    // If the current hypervisor value is not ProxMox, set the field types to hidden
-    // to prevent browser/password manager autofill
+	// If the current hypervisor value is not ProxMox, set the field types to hidden
+	// to prevent browser/password manager autofill
 	$('#APIUsername,#APIPassword').attr("type","hidden");
 
 	// Add in refresh functions for virtual machines

--- a/devices.php
+++ b/devices.php
@@ -1265,7 +1265,7 @@ $(document).ready(function() {
 
     // If the current hypervisor value is not ProxMox, set the field types to hidden
     // to prevent browser/password manager autofill
-    $('#APIUsername,#APIPassword').attr("type","hidden");
+	$('#APIUsername,#APIPassword').attr("type","hidden");
 
 	// Add in refresh functions for virtual machines
 	var VMtable=$('<div>').addClass('table border').append('<div><div>VM Name</div><div>Status</div><div>Owner</div><div>Last Updated</div></div>');
@@ -1398,13 +1398,13 @@ $(document).ready(function() {
 		if($(this).val()=='ProxMox'){
 			$('#proxmoxblock').removeClass('hide');
 			$('#snmpblock').addClass('hide');
-        	$('#APIUsername').attr("type","text");
-        	$('#APIPassword').attr("type","password");
+			$('#APIUsername').attr("type","text");
+			$('#APIPassword').attr("type","password");
 		}else{
 			// Put back any hidden / renamed fields
 			$('#proxmoxblock').addClass('hide');
 			$('#snmpblock').removeClass('hide');
-        	$('#APIUsername,#APIPassword').attr("type","hidden");
+			$('#APIUsername,#APIPassword').attr("type","hidden");
 		}
 	}).change();
 

--- a/devices.php
+++ b/devices.php
@@ -1263,6 +1263,10 @@ $(document).ready(function() {
 		$('#pdutest').dialog({minWidth: 850, position: { my: "center", at: "top", of: window },closeOnEscape: true });
 	});
 
+    // If the current hypervisor value is not ProxMox, set the field types to hidden
+    // to prevent browser/password manager autofill
+    $('#APIUsername,#APIPassword').attr("type","hidden");
+
 	// Add in refresh functions for virtual machines
 	var VMtable=$('<div>').addClass('table border').append('<div><div>VM Name</div><div>Status</div><div>Owner</div><div>Last Updated</div></div>');
 	var VMbutton=$('<button>',{'type':'button'}).css({'position':'absolute','top':'10px','right':'2px'}).text('Refresh');
@@ -1394,10 +1398,13 @@ $(document).ready(function() {
 		if($(this).val()=='ProxMox'){
 			$('#proxmoxblock').removeClass('hide');
 			$('#snmpblock').addClass('hide');
+        	$('#APIUsername').attr("type","text");
+        	$('#APIPassword').attr("type","password");
 		}else{
 			// Put back any hidden / renamed fields
 			$('#proxmoxblock').addClass('hide');
 			$('#snmpblock').removeClass('hide');
+        	$('#APIUsername,#APIPassword').attr("type","hidden");
 		}
 	}).change();
 

--- a/devices.php
+++ b/devices.php
@@ -1263,10 +1263,6 @@ $(document).ready(function() {
 		$('#pdutest').dialog({minWidth: 850, position: { my: "center", at: "top", of: window },closeOnEscape: true });
 	});
 
-	// If the current hypervisor value is not ProxMox, set the field types to hidden
-	// to prevent browser/password manager autofill
-	$('#APIUsername,#APIPassword').attr("type","hidden");
-
 	// Add in refresh functions for virtual machines
 	var VMtable=$('<div>').addClass('table border').append('<div><div>VM Name</div><div>Status</div><div>Owner</div><div>Last Updated</div></div>');
 	var VMbutton=$('<button>',{'type':'button'}).css({'position':'absolute','top':'10px','right':'2px'}).text('Refresh');
@@ -2050,26 +2046,25 @@ echo '<fieldset id="sensorreadings">
 		</fieldset>';
 		}
 
-echo '<fieldset id="deviceimages">
-	<legend>'.__("Device Images").'</legend>
-	<div>';
-		$frontpic=($templ->FrontPictureFile!='')?' src="'.$config->ParameterArray['picturepath'].'/'.$templ->FrontPictureFile.'"':'';
-		$rearpic=($templ->RearPictureFile!='')?' src="'.$config->ParameterArray['picturepath'].'/'.$templ->RearPictureFile.'"':'';
 echo '
 		<img id="devicefront" src="'.$config->ParameterArray['picturepath'].'/'.$templ->FrontPictureFile.'" alt="front of device">
 		<img id="devicerear" src="'.$config->ParameterArray['picturepath'].'/'.$templ->RearPictureFile.'" alt="rear of device">
 	</div>
-</fieldset>
-<fieldset id="proxmoxblock" class="hide">
+</fieldset>';
+
+$apiusernamefieldtype = ($dev->Hypervisor==proxmox)?"text":"hidden";
+$apipasswordfieldtype = ($dev->Hypervisor==proxmox)?"password":"hidden";
+
+echo '<fieldset id="proxmoxblock" class="hide">
 	<legend>'.__("ProxMox Configuration").'</legend>
 	<div class="table">
 		<div>
 		  <div><label for="APIUsername">'.__("API Username").'</label></div>
-		  <div><input autocomplete="off" type="text" name="APIUsername" id="APIUsername" value="'.$dev->APIUsername.'"></div>
+		  <div><input autocomplete="off" type=".$apiusernamefieldtype." name="APIUsername" id="APIUsername" value="'.$dev->APIUsername.'"></div>
 		</div>
 		<div>
 		  <div><label for="APIPassword">'.__("API Password").'</label></div>
-		  <div><input autocomplete="off" type="password" name="APIPassword" id="APIPassword" value="'.$dev->APIPassword.'"></div>
+		  <div><input autocomplete="off" type="'.$apipasswordfieldtype.'" name="APIPassword" id="APIPassword" value="'.$dev->APIPassword.'"></div>
 		</div>
 		<div>
 		  <div><label for="APIPort">'.__("API Port").'</label></div>


### PR DESCRIPTION
Proposed fix for #1391 - in JS set proxmox username/password fields to type=hidden so that unexpected browser-side autofill does not occur.   By setting these to type=hidden, the browser/DOM knows they are actually hidden instead of having to determine whether they are just not rendered visibly (hidden via CSS, etc).  Password managers appear to correectly ignore type=hidden since they are clearly not user-interactive fields.