### PR TITLE
Fix the display of Cyrillic characters in mail and allow mail to be s…

### DIFF
--- a/report-em_disabled_snmp.php
+++ b/report-em_disabled_snmp.php
@@ -8,10 +8,12 @@
 	use PHPMailer\PHPMailer\SMTP;
 
 	$mail = new PHPMailer(true);
+	$mail->CharSet = 'UTF-8';
 	$mail->SMTPDebug = SMTP::DEBUG_OFF;
 	$mail->isSMTP();
 	$mail->Host = $config->ParameterArray['SMTPServer'];
 	$mail->Port = $config->ParameterArray['SMTPPort'];
+	$mail->SMTPAutoTLS = false;
 
 	// If any port other than 25 is specified, assume encryption and authentication
 	if($config->ParameterArray['SMTPPort']!= 25){


### PR DESCRIPTION
…ent without encryption

This fix is required because PHPMailer only displays Latin characters correctly (when querying the SQL database) and requires the default TLS to be used.