### PR TITLE
Fix the display of Cyrillic characters in mail and allow mail to be s…

### DIFF
--- a/scripts/testemail.php
+++ b/scripts/testemail.php
@@ -11,11 +11,13 @@
 
 	if(isset( $_REQUEST['SMTPServer'] ) && isset( $_REQUEST['SMTPPort'] ) && isset( $_REQUEST['SMTPUser'] ) && isset( $_REQUEST['SMTPPassword'] ) && isset( $_REQUEST['FacMgrMail']) ) {
 		$mail = new PHPMailer(true);
+		$mail->CharSet = 'UTF-8';
 		$mail->SMTPDebug = SMTP::DEBUG_OFF;
 		$mail->isSMTP();
 		$mail->isHTML(true);
 		$mail->Host = $config->ParameterArray['SMTPServer'];
 		$mail->Port = $config->ParameterArray['SMTPPort'];
+		$mail->SMTPAutoTLS = false;
 
 		// If any port other than 25 is specified, assume encryption and authentication
 		if($config->ParameterArray['SMTPPort']!= 25){


### PR DESCRIPTION
…ent without encryption

This fix is required because PHPMailer only displays Latin characters correctly (when querying the SQL database) and requires the default TLS to be used.