### PR TITLE
Fix dc_stats.php bug

### DIFF
--- a/dc_stats.php
+++ b/dc_stats.php
@@ -103,7 +103,7 @@
 				}else{
 					list($width, $height, $type, $attr)=getimagesize($mapfile);
 				}
-				$mapHTML="<div class=\"canvas\" style=\"background-image: url('".urlencode($mapfile)."')\">
+				$mapHTML="<div class=\"canvas\" style=\"background-image: url('".$mapfile."')\">
 	<img src=\"css/blank.gif\" usemap=\"#datacenter\" width=\"$width\" height=\"$height\" alt=\"clearmap over canvas\">
 	<map name=\"datacenter\" data-dc=$dc->DataCenterID data-zoom=1 data-x1=0 data-y1=0>
 	</map>


### PR DESCRIPTION
due to the urlencode function using infrastructure drawings path, / (slash) character in the seemed infrastructure drawings path with encoded as %2F so it don't found drawing images.

![1](https://github.com/opendcim/openDCIM/assets/51494646/2e88f549-1c48-4798-acdc-b5f036a8c861)
![2](https://github.com/opendcim/openDCIM/assets/51494646/a723899e-ed97-44ce-9772-68c3c43e7630)
