### PR TITLE
adding a new postRoute to allow updating port labels via the api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ assets/
 scripts/jquery-ui.min.js
 scripts/jquery.min.js
 css/jquery-ui.css
+/.vs

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -425,6 +425,40 @@ paths:
       security:
       - api_key: []
       - user_id: []
+  /device/{DeviceId}/updateportlabels:
+    post:
+      summary: Update port labels
+      tags:
+      - "Device"
+      description: 'Update the port labels for a specific device.'
+      consumes:
+      - "application/json"
+      operationId: "UpdateLabel"
+      parameters:
+        - name: "DeviceId"
+          in: path  
+          required: true
+          type: string
+        - name: "method"
+          in: query
+          required: true
+          type: string
+          description: "The method for updating labels e.g. Custom, From Template, Invert Port Labels"
+          allowEmptyValue: false
+        - name: "pattern"
+          in: query
+          required: false
+          type: string
+          description: "If method is Custom we need a custom pattern e.g. (xxxx;1)"
+          allowEmptyValue: false
+      responses:
+        "401":
+          description: "Access denied."
+        "200":
+          description: "successful operation"
+      security:
+      - api_key: []
+      - user_id: []
   /device/{DeviceLabel}:
     put:
       summary: Create a new device


### PR DESCRIPTION
added api/device/{deviceid}/updateportlabels to postRoutes.php and updated the swagger.yml file to reflect the changes. This is used by our organization to bypass using the gui on large installs and may prove useful to others. also updated gitignore to ignore /.vs files for anyone that uses visual studio to edit the application to prevent accidentally checking in IDE settings files.