### PR TITLE
Fixing issue 1585, performing urlencode with the exclusion of : and /

### DIFF
--- a/dc_stats.php
+++ b/dc_stats.php
@@ -103,7 +103,7 @@
 				}else{
 					list($width, $height, $type, $attr)=getimagesize($mapfile);
 				}
-				$mapHTML="<div class=\"canvas\" style=\"background-image: url('".urlencode($mapfile)."')\">
+                $mapHTML="<div class=\"canvas\" style=\"background-image: url('".str_replace('%3A',':',str_replace('%2F','/', rawurlencode($mapfile)))."')\">
 	<img src=\"css/blank.gif\" usemap=\"#datacenter\" width=\"$width\" height=\"$height\" alt=\"clearmap over canvas\">
 	<map name=\"datacenter\" data-dc=$dc->DataCenterID data-zoom=1 data-x1=0 data-y1=0>
 	</map>


### PR DESCRIPTION
Fixes issue 1585 for `dc_stats.php`, tested with these file paths:

* `assets/drawings/example.jpg`
* `assets/drawings/A bad dir/example 2.jpg`