### PR TITLE
Replace exec with proc_open for vuln

### DIFF
--- a/create.sql
+++ b/create.sql
@@ -466,7 +466,7 @@ DROP TABLE IF EXISTS fac_MediaConnectors;
 CREATE TABLE IF NOT EXISTS fac_MediaConnectors (
   ConnectorID int(11) NOT NULL AUTO_INCREMENT,
   ConnectorType varchar(40) NOT NULL,
-  PRIMARY KEY (ConnectorIDid),
+  PRIMARY KEY (ConnectorID),
   UNIQUE KEY connectortype (ConnectorType)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 

--- a/create.sql
+++ b/create.sql
@@ -466,7 +466,7 @@ DROP TABLE IF EXISTS fac_MediaConnectors;
 CREATE TABLE IF NOT EXISTS fac_MediaConnectors (
   ConnectorID int(11) NOT NULL AUTO_INCREMENT,
   ConnectorType varchar(40) NOT NULL,
-  PRIMARY KEY (ConnectorID),
+  PRIMARY KEY (ConnectorIDid),
   UNIQUE KEY connectortype (ConnectorType)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 

--- a/report_network_map.php
+++ b/report_network_map.php
@@ -455,7 +455,6 @@ overlap = scale;
         if(!$file_written) {
             $body = "<span class=\"errmsg\">ERROR: There was a problem writing out the temp dot file. Check that php can write to /tmp</span>";
         } else {
-            $graph = array();
             $retval = 0;
             if($ft == 'svg') {
                 $header .= "image/svg+xml";
@@ -464,7 +463,23 @@ overlap = scale;
             } elseif($ft == 'jpg') {
                 $header .= "image/jpeg";
             }
-            exec($dotCommand." -T".$ft." -o".$graphfile." ".$dotfile, $graph, $retval);
+            $ft = escapeshellarg($ft);
+            $command = "$dotCommand -T $ft -o $graphfile $dotfile"
+            $descriptors = [
+                0 => ["pipe", "r"], // stdin
+                1 => ["pipe", "w"], // stdout
+                2 => ["pipe", "w"]  // stderr
+            ];
+            $dot_process = proc_open($command, $descriptors, $pipes)
+            if (is_resource($dot_process)) {
+                // Read output if necessary
+                #$output = stream_get_contents($pipes[1]);
+                // Always close pipes and the process
+                fclose($pipes[0]);
+                fclose($pipes[1]);
+                fclose($pipes[2]);
+                $retval = proc_close($dot_process);
+            }
             if($retval == 0) {
                 header($header);
                 unlink($dotfile);

--- a/report_network_map.php
+++ b/report_network_map.php
@@ -464,13 +464,13 @@ overlap = scale;
                 $header .= "image/jpeg";
             }
             $ft = escapeshellarg($ft);
-            $command = "$dotCommand -T $ft -o $graphfile $dotfile"
+            $command = "$dotCommand -T $ft -o $graphfile $dotfile";
             $descriptors = [
                 0 => ["pipe", "r"], // stdin
                 1 => ["pipe", "w"], // stdout
                 2 => ["pipe", "w"]  // stderr
             ];
-            $dot_process = proc_open($command, $descriptors, $pipes)
+            $dot_process = proc_open($command, $descriptors, $pipes);
             if (is_resource($dot_process)) {
                 // Read output if necessary
                 #$output = stream_get_contents($pipes[1]);

--- a/report_network_map.php
+++ b/report_network_map.php
@@ -463,6 +463,7 @@ overlap = scale;
             } elseif($ft == 'jpg') {
                 $header .= "image/jpeg";
             }
+            $dotCommand = escapeshellarg($dotCommand);
             $ft = escapeshellarg($ft);
             $command = "$dotCommand -T $ft -o $graphfile $dotfile";
             $descriptors = [


### PR DESCRIPTION
Hello,

This PR has been opened to address CVE-2026-28517 for the RCE in openDCIM per https://nvd.nist.gov/vuln/detail/CVE-2026-28517

Improvements:
* Sanitize command $dotCommand for shell args
* Sanitize format $ft as this comes from an input and sets headers
* Flatten dot command and arguments into string
* Use proc_open (safer) instead of exec, for simplicity sake didn't use a Graphviz wrapper library and used proc_open.

Testing:
I spun up a almalinux 9 VM with Apache and openDCIM 23.04 as per https://github.com/opendcim/openDCIM/wiki/RHEL
(The latest copy of the code appears to be broken for a clone and deploy)
Added some test data, a DC, a cabinet and a couple of cables (just random names) then was able to generate the network map report.
<IP> - dcim [11/Jun/2026:13:27:23 +0000] "POST /report_network_map.php HTTP/1.1" 200 814 "https://localhost/report_network_map.php" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0"
<IP> - dcim [11/Jun/2026:13:27:29 +0000] "POST /report_network_map.php HTTP/1.1" 200 50687 "https://localhost/report_network_map.php" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0"
<IP> - dcim [11/Jun/2026:13:27:49 +0000] "GET /report_network_map.php HTTP/1.1" 200 14979 "https://localhost/report_network_map.php" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0"

![report_network_map](https://github.com/user-attachments/assets/b36aefd9-50e2-4587-97fc-08e945c33412)


Exploit test ------------------------------------------
opendcim exploit test
https://github.com/Chocapikk/opendcim-exploit

./opendcim-exploit -e -rhost 127.0.0.1 -rport 8085 -lhost 127.0.0.1 -lport 4444 -c2 SSLShellServer -username dcim -password dcim
time=2026-06-11T23:18:42.626+10:00 level=STATUS msg="Certificate not provided. Generating a TLS Certificate"
time=2026-06-11T23:18:42.680+10:00 level=STATUS msg="Starting TLS listener on 127.0.0.1:4444"
time=2026-06-11T23:18:42.680+10:00 level=STATUS msg="Starting target" index=0 host=127.0.0.1 port=8085 ssl=false "ssl auto"=false
time=2026-06-11T23:18:42.680+10:00 level=STATUS msg="Backing up configuration and verifying RCE"
time=2026-06-11T23:18:42.686+10:00 level=ERROR msg="RCE verification failed"
time=2026-06-11T23:18:42.689+10:00 level=STATUS msg="Exploit exited with an error" exploited=false
time=2026-06-11T23:19:12.680+10:00 level=ERROR msg="Timeout met. Shutting down shell listener."
time=2026-06-11T23:19:12.685+10:00 level=STATUS msg="C2 received shutdown, killing server and client sockets for SSL shell server"
time=2026-06-11T23:19:12.685+10:00 level=STATUS msg="C2 server exited"