### PR TITLE
Use escapeshellcmd instead of args

### DIFF
--- a/report_network_map.php
+++ b/report_network_map.php
@@ -463,7 +463,7 @@ overlap = scale;
             } elseif($ft == 'jpg') {
                 $header .= "image/jpeg";
             }
-            $dotCommand = escapeshellarg($dotCommand);
+            $dotCommand = escapeshellcmd($dotCommand);
             $ft = escapeshellarg($ft);
             $command = "$dotCommand -T $ft -o $graphfile $dotfile";
             $descriptors = [


### PR DESCRIPTION
I should have used escapeshellcmd instead of ...args in #1670 @wilpig 
I've tested that this all works the same as the other PR if you can review again please.


https://www.php.net/manual/en/function.escapeshellarg.php
escapeshellcmd

(PHP 4, PHP 5, PHP 7, PHP 8)

escapeshellcmd — Escape shell metacharacters
Description[ ¶](https://www.php.net/manual/en/function.escapeshellcmd.php#refsect1-function.escapeshellcmd-description)
function escapeshellcmd([string](https://www.php.net/manual/en/language.types.string.php) $command): [string](https://www.php.net/manual/en/language.types.string.php)

escapeshellcmd() escapes any characters in a string that might be used to trick a shell command into executing arbitrary commands. This function should be used to make sure that any data coming from user input is escaped before this data is passed to the [exec()](https://www.php.net/manual/en/function.exec.php) or [system()](https://www.php.net/manual/en/function.system.php) functions, or to the [backtick operator](https://www.php.net/manual/en/language.operators.execution.php).

Following characters are preceded by a backslash: &#;`|*?~<>^()[]{}$\, \x0A and \xFF. ' and " are escaped only if they are not paired. On Windows, all these characters plus % and ! are preceded by a caret (^).
